### PR TITLE
corrected input units

### DIFF
--- a/idle.html
+++ b/idle.html
@@ -46,7 +46,7 @@
   similar option in other Chromium-based browsers.
 </p>
 <p>
-  <label for="threshold">Threshold (seconds):</label>
+  <label for="threshold">Threshold (milliseconds):</label>
   <input type="number" id="threshold" value="60000"></input>
   <button id="start">Start</button>
   <button id="requestPermission">Request Permission</button>


### PR DESCRIPTION
The value in the input text box is accepting milliseconds, which the label shows the unit as seconds. This might lead to a confusion when we enter 61 in the text box and it still shows an error that the minimum threshold needs to be 1 minute.